### PR TITLE
Python 3 compatibility

### DIFF
--- a/addon/globalPlugins/switchSynth.py
+++ b/addon/globalPlugins/switchSynth.py
@@ -1,5 +1,8 @@
 #Copyright 2013-2016 Tyler Spivey, released under the GPL
-import cPickle
+try:
+	import cPickle
+except ModuleNotFoundError:
+	import _pickle as cPickle
 import os
 import config
 import globalPluginHandler

--- a/buildVars.py
+++ b/buildVars.py
@@ -22,13 +22,19 @@ To switch synthesizers, press control+shift+NVDA+1 through control+shift+NVDA+6.
 To save the current voice in the currently selected slot, press control+shift+NVDA+v."""
 	),
 	# version
-	"addon_version" : "1.02",
+	"addon_version" : "1.03",
 	# Author(s)
 	"addon_author" : "Tyler Spivey <tspivey@pcdesk.net>",
 	# URL for the add-on documentation support
 	"addon_url" : None,
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
+	# Minimum NVDA version supported (e.g. "2018.3")
+	"addon_minimumNVDAVersion" : "2019.2.0",
+	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
+	"addon_lastTestedNVDAVersion" : "2019.3.0",
+	# Add-on update channel (default is stable or None)
+	"addon_updateChannel" : None,
 }
 
 

--- a/manifest.ini.tpl
+++ b/manifest.ini.tpl
@@ -5,3 +5,6 @@ author = "{addon_author}"
 url = {addon_url}
 version = {addon_version}
 docFileName = {addon_docFileName}
+minimumNVDAVersion = {addon_minimumNVDAVersion}
+lastTestedNVDAVersion = {addon_lastTestedNVDAVersion}
+updateChannel = {addon_updateChannel}

--- a/sconstruct
+++ b/sconstruct
@@ -8,9 +8,10 @@ import gettext
 import os
 import os.path
 import zipfile
+import sys
+sys.dont_write_bytecode = True
 
 import buildVars
-
 
 def md2html(source, dest):
 	import markdown
@@ -22,7 +23,7 @@ def md2html(source, dest):
 	}
 	with codecs.open(source, "r", "utf-8") as f:
 		mdText = f.read()
-		for k, v in headerDic.iteritems():
+		for k, v in headerDic.items():
 			mdText = mdText.replace(k, v, 1)
 		htmlText = markdown.markdown(mdText)
 	with codecs.open(dest, "w", "utf-8") as f:
@@ -51,9 +52,24 @@ def mdTool(env):
 	)
 	env['BUILDERS']['markdown']=mdBuilder
 
+vars = Variables()
+vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
+vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
+vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(ENV=os.environ, tools=['gettexttool', mdTool])
+env = Environment(variables=vars, ENV=os.environ, tools=['gettexttool', mdTool])
 env.Append(**buildVars.addon_info)
+
+if env["dev"]:
+	import datetime
+	buildDate = datetime.datetime.now()
+	year, month, day = str(buildDate.year), str(buildDate.month), str(buildDate.day)
+	env["addon_version"] = "".join([year, month.zfill(2), day.zfill(2), "-dev"])
+	env["channel"] = "dev"
+elif env["version"] is not None:
+	env["addon_version"] = env["version"]
+if "channel" in env and env["channel"] is not None:
+	env["addon_updateChannel"] = env["channel"]
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 
@@ -66,7 +82,6 @@ def manifestGenerator(target, source, env, for_signature):
 	action = env.Action(lambda target, source, env : generateManifest(source[0].abspath, target[0].abspath) and None,
 	lambda target, source, env : "Generating manifest %s" % target[0])
 	return action
-
 
 def translatedManifestGenerator(target, source, env, for_signature):
 	dir = os.path.abspath(os.path.join(os.path.dirname(str(source[0])), ".."))
@@ -90,8 +105,6 @@ def createAddonHelp(dir):
 		readmeTarget = env.Command(readmePath, "readme.md", Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, readmeTarget)
 
-
-
 def createAddonBundleFromPath(path, dest):
 	""" Creates a bundle from a directory that contains an addon manifest file."""
 	basedir = os.path.abspath(path)
@@ -106,14 +119,21 @@ def createAddonBundleFromPath(path, dest):
 	return dest
 
 def generateManifest(source, dest):
+	addon_info = buildVars.addon_info
+	addon_info["addon_version"] = env["addon_version"]
+	addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
-	manifest = manifest_template.format(**buildVars.addon_info)
+	manifest = manifest_template.format(**addon_info)
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)
 
 def generateTranslatedManifest(source, language, out):
-	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	# No ugettext in Python 3.
+	if sys.version_info.major == 2:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	else:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])
@@ -153,7 +173,7 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars={
-		'gettext_package_bugs_address' : 'nvda-translations@freelists.org',
+		'gettext_package_bugs_address' : 'nvda-translations@groups.io',
 		'gettext_package_name' : buildVars.addon_info['addon_name'],
 		'gettext_package_version' : buildVars.addon_info['addon_version']
 	}
@@ -172,3 +192,4 @@ env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)
 env.Default(addon)
+env.Clean (addon, ['.sconsign.dblite', 'addon/doc/en/'])


### PR DESCRIPTION
Hi Tyler, this PR fixes Python 3 import issue, updates build version and also updates add-on template to include new NVDA compatibility flags. I believe now it would only be possible to build it using python 3 scons - but that's the case for all add-ons that want to be compatible with python 3 NVDA builds.