### PR TITLE
Another fix for python 3 compatibility

### DIFF
--- a/addon/globalPlugins/switchSynth.py
+++ b/addon/globalPlugins/switchSynth.py
@@ -39,7 +39,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if hasattr(config.conf['speech'][speech.getSynth().name], 'items'):
 			items = config.conf['speech'][speech.getSynth().name].items()
 		else:
-			items = config.conf['speech'][speech.getSynth().name].iteritems()
+			try:
+				items = config.conf['speech'][speech.getSynth().name].iteritems()
+			except AttributeError:
+				items = config.conf['speech'][speech.getSynth().name].items()
 		self.synths[self.slot]['config'] = dict(items)
 		self.write()
 		ui.message(_("saved"))

--- a/buildVars.py
+++ b/buildVars.py
@@ -22,7 +22,7 @@ To switch synthesizers, press control+shift+NVDA+1 through control+shift+NVDA+6.
 To save the current voice in the currently selected slot, press control+shift+NVDA+v."""
 	),
 	# version
-	"addon_version" : "1.03",
+	"addon_version" : "1.04",
 	# Author(s)
 	"addon_author" : "Tyler Spivey <tspivey@pcdesk.net>",
 	# URL for the add-on documentation support


### PR DESCRIPTION
Hello! This is another python 3 compatibility fix that I somehow missed last time. Without this an exception is thrown impossible to update when trying to overwrite settings of an already assigned synth slot.